### PR TITLE
Security: CodeQL hardening pass — resolve all 8 open alerts

### DIFF
--- a/docs/SECURITY_TRIAGE.md
+++ b/docs/SECURITY_TRIAGE.md
@@ -1,0 +1,27 @@
+# Security Triage — CodeQL Alert Log
+
+Running record of every CodeQL alert in the repo's Security tab: what it was,
+what we did, and why. Future scans that re-flag a dismissed pattern should be
+checked against this log before any code churn.
+
+## 2026-07-19 — branch `security/codeql-hardening`
+
+| # | Rule | Severity | Location | Disposition |
+|---|------|----------|----------|-------------|
+| 21 | js/clear-text-storage-of-sensitive-data | error/high | `src/stores/settingsStore.ts` | **Fixed.** The legacy Spotify localStorage fallback wrote the client secret in plaintext when safeStorage was unavailable. The secret is now persisted only through safeStorage encryption; without safeStorage it stays in-memory for the session (re-entry required next launch). The startup migration path still reads and deletes any pre-existing legacy key. |
+| 20 | js/tainted-format-string | warning/high | `electron/server.ts` (artist sync) | **Fixed.** Request-supplied id moved out of the format string into a console argument. |
+| 19 | js/tainted-format-string | warning/high | `electron/server.ts` (playlist sync) | **Fixed.** Same pattern. |
+| 18 | js/tainted-format-string | warning/high | `src/views/SearchView.vue` (bulk link download) | **Fixed.** Pasted-link type/id moved into console arguments. |
+| 16 | js/stack-trace-exposure | warning/medium | `electron/server.ts` `sendJSON` | **Fixed centrally.** `sendJSON` now scrubs `stack` fields (and collapses raw `Error` objects to message-only) from every error-status payload — a chokepoint guarantee covering all current and future handlers. Server binds to 127.0.0.1 only, so exposure was already local-only. |
+| 15 | js/request-forgery | error/critical | `electron/server.ts` (Deezer API proxy) | **Mitigated + hardened → dismiss.** Endpoint is resolved against `https://api.deezer.com` and the full origin is pinned: protocol must be `https:`, hostname must equal `api.deezer.com`, port must be default. CodeQL cannot recognize the custom sanitizer; dismissed with this justification. |
+| 14 | js/request-forgery | error/critical | `electron/server.ts` (redirect resolver) | **Mitigated + hardened → dismiss.** `isRedirectSafe()` runs on the initial URL and every redirect hop: http/https only, default ports only (added this pass), private/link-local/localhost ranges blocked, and a host allowlist (`.deezer.com`, `.spotify.com`, `.dzcdn.net`, exact `deezer.page.link`) with correct suffix-vs-exact matching. Dismissed with this justification. |
+| 23 | js/weak-cryptographic-algorithm | warning/high | `electron/services/qobuzAuth.ts` (request signing) | **Won't fix → dismiss.** MD5 is mandated by Qobuz's API contract — their gateway validates `md5(object+method+params+timestamp+secret)`. It authenticates requests to their service and protects no data of ours; any other algorithm is rejected by Qobuz. Documented at the call site. |
+
+### Standing posture
+
+- The local HTTP server binds to `127.0.0.1` only.
+- Service credentials (Deezer ARL, Spotify client secret, Qobuz token) are
+  stored via OS safeStorage / userData files, never in cleartext web storage,
+  never in settings exports or backups.
+- Any new outbound-fetch endpoint must pin its origin (scheme + host + port)
+  or route through `isRedirectSafe()`.

--- a/electron/server.ts
+++ b/electron/server.ts
@@ -179,6 +179,9 @@ function isRedirectSafe(targetUrl: string): boolean {
     const parsed = new URL(targetUrl)
     // Only allow http/https
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false
+    // Default ports only — an allowlisted host can't be used to poke at
+    // arbitrary services on non-standard ports.
+    if (parsed.port && parsed.port !== '80' && parsed.port !== '443') return false
     const hostname = parsed.hostname.toLowerCase()
     // Block private/internal IPs
     if (hostname === 'localhost' || hostname.startsWith('127.') ||
@@ -2923,7 +2926,9 @@ export class DeemixServer extends EventEmitter {
       // Build from a fixed base and assert the host so a crafted `endpoint`
       // (e.g. starting with `@` or `//`) can't re-point the request off Deezer.
       const target = new URL(endpoint, 'https://api.deezer.com')
-      if (target.hostname !== 'api.deezer.com') {
+      // Full-origin pin, not just hostname: a crafted endpoint can't switch
+      // scheme (protocol-relative //host) or smuggle a non-default port.
+      if (target.protocol !== 'https:' || target.hostname !== 'api.deezer.com' || target.port !== '') {
         reject(new Error('Invalid Deezer API endpoint'))
         return
       }
@@ -2990,6 +2995,17 @@ export class DeemixServer extends EventEmitter {
   }
 
   private sendJSON(res: ServerResponse, data: any, status = 200): void {
+    // Single chokepoint for responses: error payloads never carry stack traces
+    // to the client (CodeQL #16). Handlers already send message-only errors;
+    // this guarantees it for every current and future handler, including any
+    // Error object serialized wholesale or nested `stack` fields.
+    if (status >= 400 && data && typeof data === 'object') {
+      if (data instanceof Error) {
+        data = { error: data.message }
+      } else {
+        data = JSON.parse(JSON.stringify(data, (key, value) => (key === 'stack' ? undefined : value)))
+      }
+    }
     res.writeHead(status, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify(data))
   }
@@ -4077,7 +4093,9 @@ export class DeemixServer extends EventEmitter {
 
       // Run sync in background, return immediately
       playlistSync.syncPlaylist(id).catch(err =>
-        console.error(`[Server] Sync failed for ${id}:`, err)
+        // Request-supplied id passed as an argument, not interpolated into the
+        // format string (CodeQL #19: tainted format string / log forgery).
+        console.error('[Server] Sync failed for playlist:', id, err)
       )
 
       this.sendJSON(res, { success: true, message: 'Sync started' })
@@ -4304,7 +4322,8 @@ export class DeemixServer extends EventEmitter {
         return
       }
       artistSync.syncArtist(id).catch(err =>
-        console.error(`[Server] Artist sync failed for ${id}:`, err)
+        // Request-supplied id passed as an argument, not interpolated (CodeQL #20).
+        console.error('[Server] Artist sync failed for artist:', id, err)
       )
       this.sendJSON(res, { success: true, message: 'Artist sync started' })
     } catch (error: any) {

--- a/electron/services/qobuzAuth.ts
+++ b/electron/services/qobuzAuth.ts
@@ -236,6 +236,11 @@ class QobuzAuth {
       .map((k) => `${k}${params[k]}`)
       .join('')
     const raw = `${objectName}${methodName}${serialized}${timestamp}${appSecret}`
+    // MD5 is mandated by Qobuz's API contract — their gateway validates exactly
+    // this digest. It is a request-authentication token for THEIR service, not a
+    // confidentiality or password-storage mechanism of ours; a stronger hash
+    // would simply be rejected. (CodeQL js/weak-cryptographic-algorithm #23 —
+    // dismissed as protocol-mandated.)
     return crypto.createHash('md5').update(raw).digest('hex')
   }
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -644,6 +644,10 @@ export const useSettingsStore = defineStore('settings', () => {
         return
       }
 
+      // The client secret is only ever persisted through safeStorage encryption.
+      // Without safeStorage there is no safe place for it in localStorage — it
+      // stays in-memory for the session and must be re-entered next launch
+      // (CodeQL #21: cleartext storage of sensitive data).
       const data: any = {}
       if (window.electronAPI?.safeStorage) {
         if (clientId) {
@@ -656,7 +660,9 @@ export const useSettingsStore = defineStore('settings', () => {
         }
       } else {
         if (clientId) data.clientId = { data: clientId, encrypted: false }
-        if (clientSecret) data.clientSecret = { data: clientSecret, encrypted: false }
+        if (clientSecret) {
+          console.warn('[Settings] safeStorage unavailable — Spotify client secret kept in-memory only (not persisted)')
+        }
       }
       localStorage.setItem(LEGACY_SPOTIFY_STORAGE_KEY, JSON.stringify(data))
     } catch (e) {

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -653,7 +653,8 @@ async function handlePaste(e: ClipboardEvent) {
         }
       }
     } catch (err) {
-      console.error(`[Search] Bulk download failed for ${link.type}/${link.id}:`, err)
+      // Pasted-link values passed as arguments, not interpolated (CodeQL #18).
+      console.error('[Search] Bulk download failed for link:', link.type, link.id, err)
       failed++
     }
     // Pace between pasted links so a big batch doesn't burst Deezer's API (#84).


### PR DESCRIPTION
Works through every open alert in the Security tab. Dispositions:

## Fixed in code (should auto-close on merge)
- **#21 Cleartext storage of sensitive data (high)** — the legacy Spotify localStorage fallback could write the client secret in plaintext when OS safeStorage was unavailable. The secret is now only ever persisted safeStorage-encrypted; without safeStorage it stays in-memory for the session. Startup migration still reads + deletes any pre-existing legacy key.
- **#18/#19/#20 Tainted format string (high)** — request/pasted ids moved out of `console.error` format strings into arguments (log-forgery hygiene).
- **#16 Stack trace exposure (medium)** — `sendJSON` now scrubs `stack` fields and collapses raw `Error` objects to message-only on every error-status response. Central chokepoint; covers all future handlers too.

## Hardened, then to be dismissed as mitigated
- **#14 SSRF (critical)** — `isRedirectSafe()` already allowlisted hosts and blocked private ranges on the initial URL and every hop; this pass adds a default-port pin.
- **#15 SSRF (critical)** — Deezer proxy now pins the full origin (`https:` + `api.deezer.com` + default port), not just hostname.

CodeQL can't model custom sanitizers, so these two stay flagged regardless — dismissal with justification after merge.

## To be dismissed as won't-fix
- **#23 Weak crypto / MD5 (high)** — MD5 is Qobuz's mandated request-signature algorithm; their gateway validates exactly this digest. Documented at the call site.

Full disposition log added at `docs/SECURITY_TRIAGE.md`.

**Verification:** typecheck clean; CodeQL PR scan on this branch should report #16–#21 as fixed. Functional smoke of Spotify credential save, Deezer proxy, link analyzer, and sync endpoints planned on the RC build before merge.